### PR TITLE
Update Test Suite

### DIFF
--- a/tests/UnserializeTest.php
+++ b/tests/UnserializeTest.php
@@ -16,16 +16,17 @@ class UnserializeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Tests\\Brumann\\Polyfill\\Foo', $unserialized);
     }
 
-    public function test_unserialize_with_class_allowed_returns_instance()
+    public function test_unserialize_with_cqn_returns_instance()
     {
         $foo = new Foo();
         $serialized = serialize($foo);
         $options = array(
             'allowed_classes' => array('Tests\\Brumann\\Polyfill\\Foo'),
         );
+
         $unserialized = Unserialize::unserialize($serialized, $options);
 
-        $this->assertInstanceOf('\\Tests\\Brumann\\Polyfill\\Foo', $unserialized);
+        $this->assertInstanceOf('Tests\\Brumann\\Polyfill\\Foo', $unserialized);
     }
 
     public function test_unserialize_with_fqcn_allowed_returns_instance()
@@ -35,6 +36,7 @@ class UnserializeTest extends \PHPUnit_Framework_TestCase
         $options = array(
             'allowed_classes' => array('\\Tests\\Brumann\\Polyfill\\Foo'),
         );
+
         $unserialized = Unserialize::unserialize($serialized, $options);
 
         $this->assertInstanceOf('__PHP_Incomplete_Class', $unserialized);
@@ -53,22 +55,19 @@ class UnserializeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('__PHP_Incomplete_Class', $unserialized);
     }
 
+    /**
+     * @requires PHP < 7.0
+     *
+     * @expectedException \PHPUnit_Framework_Error_Warning
+     * @expectedMessage allowed_classes option should be array or boolean
+     */
     public function test_unserialize_with_allowed_classes_null_behaves_like_php71()
     {
-        // @see https://bugs.php.net/bug.php?id=73836
-        $this->markTestSkipped('Strict type warning is not present in PHP 7.0');
         $foo = new Foo();
         $serialized = serialize($foo);
         $options = array(
             'allowed_classes' => null,
         );
-
-        /*
-         * When re-enabling this test you should place this as an annotation,
-         * because otherwise older versions of PHPUnit will complain.
-         */
-        $this->expectException('\\PHPUnit_Framework_Error_Warning');
-        $this->expectMessage('allowed_classes option should be array or boolean');
 
         Unserialize::unserialize($serialized, $options);
     }
@@ -102,6 +101,7 @@ class UnserializeTest extends \PHPUnit_Framework_TestCase
         );
 
         $unserialized = Unserialize::unserialize($serialized, $options);
+
         $this->assertInstanceOf('\\Tests\\Brumann\\Polyfill\\Foo', $unserialized);
         $this->assertInstanceOf('__PHP_Incomplete_Class', $unserialized->bar);
     }
@@ -121,7 +121,7 @@ class UnserializeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\\Tests\\Brumann\\Polyfill\\Foo', $unserialized->foo);
     }
 
-    public function test_unserialize_with_allowed_false_serializes_string()
+    public function test_unserialize_with_allowed_classes_false_serializes_string()
     {
         $string = 'This is an ordinary string';
         $serialized = serialize($string);
@@ -134,7 +134,7 @@ class UnserializeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($string, $unserialized);
     }
 
-    public function test_unserialize_with_allowed_false_serializes_bool()
+    public function test_unserialize_with_allowed_classes_false_serializes_bool()
     {
         $bool = true;
         $serialized = serialize($bool);
@@ -147,7 +147,7 @@ class UnserializeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($bool, $unserialized);
     }
 
-    public function test_unserialize_with_allowed_false_serializes_array()
+    public function test_unserialize_with_allowed_classes_false_serializes_array()
     {
         $array = array(
             'key' => 42,


### PR DESCRIPTION
- Fix style in tests to have an empty line between logical blocks (Arrange, Act, Assert)
- Update skipped test to only skip in PHP 7.0