### PR TITLE
Test against newer php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
+  - '7.3'
 
 before_install:
   - phpenv config-rm xdebug.ini


### PR DESCRIPTION
This is mostly a formality, as it should use the 'normal' functions on these versions.