### PR TITLE
Test improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
   include:
     - php: '5.3'
       dist: precise
-      env: PHPUNIT_VERSION=4.8
+      env: PHPUNIT_VERSION=4.8.36
     - php: '5.4'
       dist: trusty
-      env: PHPUNIT_VERSION=4.8
+      env: PHPUNIT_VERSION=4.8.36
     - php: '5.5'
       dist: trusty
-      env: PHPUNIT_VERSION=4.8
+      env: PHPUNIT_VERSION=4.8.36
     - php: '5.6'
       dist: trusty
       env: PHPUNIT_VERSION=5.7

--- a/tests/UnserializeTest.php
+++ b/tests/UnserializeTest.php
@@ -3,8 +3,9 @@
 namespace Tests\Brumann\Polyfill;
 
 use Brumann\Polyfill\Unserialize;
+use PHPUnit\Framework\TestCase;
 
-class UnserializeTest extends \PHPUnit_Framework_TestCase
+class UnserializeTest extends TestCase
 {
     public function provideInstances()
     {


### PR DESCRIPTION
# Changed log
- Using the `PHPUnit\Framework\TestCase` namespace to be compatible with future PHPUnit versions.
And it can use `4.8.36` to be final PHPUnit `4.8` version to accomplish this.