### PR TITLE
Prevent circumvention via specially crafted serialized string

### DIFF
--- a/src/DisallowedClassesSubstitutor.php
+++ b/src/DisallowedClassesSubstitutor.php
@@ -10,7 +10,7 @@ namespace Brumann\Polyfill;
 final class DisallowedClassesSubstitutor
 {
     const PATTERN_STRING = '#s:(\d+):(")#';
-    const PATTERN_OBJECT = '#(^|;)O:\d+:"([^"]*)":(\d+):\{#';
+    const PATTERN_OBJECT = '#(^|;)O:[+-]?\d+:"([^"]*)":(\d+):\{#';
 
     /**
      * @var string


### PR DESCRIPTION
According to upstream sources a sign (`+`, `-`) is accepted before the length: https://github.com/php/php-src/blob/PHP-5.4.45/ext/standard/var_unserializer.re#L260-L266

So it is possible to circumvent the polyfill by manually adding it, i.e.:

`O:9:"Exception"` vs `O:+9:"Exception"`